### PR TITLE
Add ament_lint format check to the workflow file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+# Ref:https://github.com/ament/ament_lint/blob/master/ament_clang_format/ament_clang_format/configuration/.clang-format
+---
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+...

--- a/.github/workflows/ROS2-Dashing.yaml
+++ b/.github/workflows/ROS2-Dashing.yaml
@@ -23,11 +23,11 @@ jobs:
                   sudo apt install ros-dashing-desktop
 
                   source /opt/ros/dashing/setup.bash
-            - name: Clone repository
+            - uses: actions/checkout@v2-beta
+            - name: Copy repository
               run: |
-                  mkdir -p ~/ros2_ws/src
-                  cd ~/ros2_ws/src
-                  git clone https://github.com/SSL-Roots/consai2r2
+                  mkdir -p ~/ros2_ws/src/consai2r2
+                  cp -rf . ~/ros2_ws/src/consai2r2
             - name: Install dependencies
               run: |
                   source /opt/ros/dashing/setup.bash

--- a/.github/workflows/ROS2-Dashing.yaml
+++ b/.github/workflows/ROS2-Dashing.yaml
@@ -45,4 +45,12 @@ jobs:
                   cd ~/ros2_ws
                   colcon build
                   source ~/ros2_ws/install/setup.bash
+            - name: Test packages
+              run: |
+                  source /opt/ros/dashing/setup.bash
+                  source ~/ros2_ws/install/setup.bash
+                  cd ~/ros2_ws
+                  colcon test
+                  colcon test-result --verbose
+
 

--- a/consai2r2_examples/launch/joystick_example.launch.py
+++ b/consai2r2_examples/launch/joystick_example.launch.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2019 SSL-Roots
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from launch import LaunchDescription
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument

--- a/consai2r2_examples/launch/joystick_example.launch.py
+++ b/consai2r2_examples/launch/joystick_example.launch.py
@@ -19,8 +19,8 @@
 # THE SOFTWARE.
 
 from launch import LaunchDescription
-from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -28,36 +28,35 @@ def generate_launch_description():
 
     # parameter
     dev = LaunchConfiguration('dev')
-    sim = LaunchConfiguration('sim') #TODO : 現在未使用 シミュレータの切り替え用
+    # sim = LaunchConfiguration('sim')  # TODO : 現在未使用 シミュレータの切り替え用
     # TODO : consai2r2_descriptionからのパラメータ読み込み
-    
+
     declare_dev_cmd = DeclareLaunchArgument(
-            'dev', default_value='/dev/input/js0',
-            description='joystick device file'
+        'dev', default_value='/dev/input/js0',
+        description='joystick device file'
     )
-    
+
     start_joy_node_cmd = Node(
-            package='joy', node_executable='joy_node',
-            output='screen',
-            parameters=[{'dev' : dev}]
+        package='joy', node_executable='joy_node',
+        output='screen',
+        parameters=[{'dev': dev}]
     )
-    
+
     start_teleop_node_cmd = Node(
-            package='consai2r2_teleop', node_executable='teleop_node',
-            output='screen'
+        package='consai2r2_teleop', node_executable='teleop_node',
+        output='screen'
     )
-    
+
     start_sender_cmd = Node(
-            package='consai2r2_sender', node_executable='sim_sender',
-            output='screen'
+        package='consai2r2_sender', node_executable='sim_sender',
+        output='screen'
     )
-    
+
     ld = LaunchDescription()
-    
+
     ld.add_action(declare_dev_cmd)
     ld.add_action(start_joy_node_cmd)
     ld.add_action(start_teleop_node_cmd)
     ld.add_action(start_sender_cmd)
 
     return ld
-    

--- a/consai2r2_sender/CMakeLists.txt
+++ b/consai2r2_sender/CMakeLists.txt
@@ -26,7 +26,7 @@ protobuf_generate_cpp(PROTO_CPP PROTO_H
 )
 
 include_directories(include ${CMAKE_CURRENT_BINARY_DIR})
-add_executable(sim_sender 
+add_executable(sim_sender
   src/sim_sender.cpp
   ${PROTO_CPP}
   ${PROTO_H}

--- a/consai2r2_sender/src/sim_sender.cpp
+++ b/consai2r2_sender/src/sim_sender.cpp
@@ -1,3 +1,22 @@
+// Copyright (c) 2019 SSL-Roots
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <iostream>
 #include <memory>

--- a/consai2r2_teleop/CMakeLists.txt
+++ b/consai2r2_teleop/CMakeLists.txt
@@ -28,7 +28,7 @@ ament_target_dependencies(joystick_component
   std_msgs
   sensor_msgs
   consai2r2_msgs
-  )
+)
 rclcpp_components_register_nodes(joystick_component "joystick::JoystickComponent")
 
 add_executable(teleop_node src/teleop_node.cpp)

--- a/consai2r2_teleop/include/consai2r2_teleop/joystick_component.hpp
+++ b/consai2r2_teleop/include/consai2r2_teleop/joystick_component.hpp
@@ -1,3 +1,23 @@
+// Copyright (c) 2019 SSL-Roots
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #ifndef JOYSTICK_COMPONENT_HPP_
 #define JOYSTICK_COMPONENT_HPP_
 

--- a/consai2r2_teleop/include/consai2r2_teleop/visibility_control.h
+++ b/consai2r2_teleop/include/consai2r2_teleop/visibility_control.h
@@ -1,3 +1,19 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Ref: https://github.com/ros2/examples/blob/master/rclcpp/minimal_composition/include/minimal_composition/visibility.h
+
 #ifndef COMPOSITION__VISIBILITY_CONTROL_H_
 #define COMPOSITION__VISIBILITY_CONTROL_H_
 

--- a/consai2r2_teleop/src/joystick_component.cpp
+++ b/consai2r2_teleop/src/joystick_component.cpp
@@ -1,3 +1,22 @@
+// Copyright (c) 2019 SSL-Roots
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include "consai2r2_teleop/joystick_component.hpp"
 

--- a/consai2r2_teleop/src/teleop_node.cpp
+++ b/consai2r2_teleop/src/teleop_node.cpp
@@ -1,3 +1,22 @@
+// Copyright (c) 2019 SSL-Roots
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <rclcpp/rclcpp.hpp>
 #include <memory>


### PR DESCRIPTION

以下の変更をしています。

- ソースファイルにライセンスとコピーライトの追記
- workflow ファイルの更新
  - checkoutアクションでブランチを切り替えてビルド&テスト
  - colcon test (メインはlintによるフォーマットチェック) の追加
- ament_frake8を通すためのjoystick_example.launch.pyの修正
- .clang-formatファイルの追加（amentリポジトリから流用）

悩みましたが、ament_lintによるチェックをCIに追加することにしました。
みなさんlintを使い始めてるようなので、ね。

毎回ビルドは成功するけどlintのチェックがダメでモチベが下がるようなら
対策を考えます。
（workflowを２つに分けてもいいかな、と思いました。（が、めんどくさい））