### PR TITLE
fix format of sim_sender.cpp

### DIFF
--- a/consai2r2_sender/src/sim_sender.cpp
+++ b/consai2r2_sender/src/sim_sender.cpp
@@ -58,13 +58,14 @@ public:
     sendto(sock, word.c_str(), word.length(), 0, (struct sockaddr *)&addr, sizeof(addr));
   }
 
-  ~simple_udp() { close(sock); }
+  ~simple_udp() {close(sock);}
 };
 
 class SimSender : public rclcpp::Node
 {
 public:
-  SimSender() : Node("consai2r2_sim_sender")
+  SimSender()
+  : Node("consai2r2_sim_sender")
   {
     std::string host;
     int port;


### PR DESCRIPTION
#28 の対応。

ament_uncrustifyが失敗していたので修正した。