### PR TITLE
Fix reuse address option in multicast class

### DIFF
--- a/consai2r2_receiver/include/consai2r2_receiver/multicast.hpp
+++ b/consai2r2_receiver/include/consai2r2_receiver/multicast.hpp
@@ -38,7 +38,7 @@ public:
   {
     asio::ip::address addr = asio::ip::address::from_string(ip);
     if (!addr.is_multicast()) {
-      throw std::runtime_error("excpeted multicast address");
+      throw std::runtime_error("expected multicast address");
     }
 
     socket.set_option(asio::socket_base::reuse_address(true));

--- a/consai2r2_receiver/include/consai2r2_receiver/multicast.hpp
+++ b/consai2r2_receiver/include/consai2r2_receiver/multicast.hpp
@@ -34,23 +34,23 @@ class MulticastReceiver
 {
 public:
   MulticastReceiver(const std::string & ip, const int port)
-  : socket(io_service, asio::ip::udp::v4())
+  : socket_(io_service_, asio::ip::udp::v4())
   {
     asio::ip::address addr = asio::ip::address::from_string(ip);
     if (!addr.is_multicast()) {
       throw std::runtime_error("expected multicast address");
     }
 
-    socket.set_option(asio::socket_base::reuse_address(true));
-    socket.set_option(asio::ip::multicast::join_group(addr.to_v4()));
-    socket.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port));
-    socket.non_blocking(true);
+    socket_.set_option(asio::socket_base::reuse_address(true));
+    socket_.set_option(asio::ip::multicast::join_group(addr.to_v4()));
+    socket_.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port));
+    socket_.non_blocking(true);
   }
 
   size_t receive(std::vector<char> & msg)
   {
     boost::system::error_code error;
-    const size_t received = socket.receive(asio::buffer(msg), 0, error);
+    const size_t received = socket_.receive(asio::buffer(msg), 0, error);
     if (error && error != asio::error::message_size) {
       throw boost::system::system_error(error);
       return 0;
@@ -58,11 +58,11 @@ public:
     return received;
   }
 
-  size_t available() {return socket.available();}
+  size_t available() {return socket_.available();}
 
 private:
-  asio::io_service io_service;
-  asio::ip::udp::socket socket;
+  asio::io_service io_service_;
+  asio::ip::udp::socket socket_;
 };
 
 #endif  // CONSAI2R2_RECEIVER__MULTICAST_HPP_


### PR DESCRIPTION
#49 に対応。

- オプションを反映させるため、reuse_addressをセットした後にbindする
- メンバ変数のendpointを削除